### PR TITLE
Minor rendering adjustments

### DIFF
--- a/lib/indent-guide-improved-element.coffee
+++ b/lib/indent-guide-improved-element.coffee
@@ -5,7 +5,7 @@ styleGuide = (element, point, length, stack, active, editor, rowMap, basePixelPo
   element.classList[if stack then 'add' else 'remove']('indent-guide-stack')
   element.classList[if active then 'add' else 'remove']('indent-guide-active')
 
-  if editor.isFoldedAtBufferRow(Math.max(point.row - 1, 0))
+  if length <= 1 || editor.isFoldedAtBufferRow(Math.max(point.row - 1, 0))
     element.style.height = '0px'
     return
 

--- a/lib/indent-guide-improved-element.coffee
+++ b/lib/indent-guide-improved-element.coffee
@@ -11,7 +11,8 @@ styleGuide = (element, point, length, stack, active, editor, rowMap, basePixelPo
 
   row = rowMap.firstScreenRowForBufferRow(point.row)
   indentSize = editor.getTabLength()
-  left = point.column * indentSize * editor.getDefaultCharWidth() - scrollLeft
+  buffer = editor.getDefaultCharWidth() * 0.5
+  left = (point.column + 1) * indentSize * editor.getDefaultCharWidth() - scrollLeft - buffer
   top = basePixelPos + lineHeightPixel * (row - baseScreenRow) - scrollTop
 
   element.style.left = "#{left}px"

--- a/styles/indent-guide-improved.less
+++ b/styles/indent-guide-improved.less
@@ -1,21 +1,15 @@
 @import "syntax-variables";
 
-@opposite: contrast(@syntax-background-color);
-
 .indent-guide-improved {
   width: 1px;
   z-index: 100;
   position: absolute;
 }
 
-.indent-guide-improved {
-  background-color: @syntax-indent-guide-color;
-}
-
 .indent-guide-improved.indent-guide-stack {
-  background-color: mix(@syntax-indent-guide-color, @opposite, 60%);
+  background-color: lighten(@syntax-background-color, 5%);
 }
 
 .indent-guide-improved.indent-guide-stack.indent-guide-active {
-  background-color: mix(@syntax-indent-guide-color, @opposite, 10%);
+  background-color: lighten(@syntax-background-color, 15%);
 }

--- a/styles/indent-guide-improved.less
+++ b/styles/indent-guide-improved.less
@@ -1,5 +1,7 @@
 @import "syntax-variables";
 
+@contrast: contrast(@syntax-background-color);
+
 .indent-guide-improved {
   width: 1px;
   z-index: 100;
@@ -7,9 +9,9 @@
 }
 
 .indent-guide-improved.indent-guide-stack {
-  background-color: lighten(@syntax-background-color, 5%);
+  background-color: mix(@contrast, @syntax-background-color, 5%);
 }
 
 .indent-guide-improved.indent-guide-stack.indent-guide-active {
-  background-color: lighten(@syntax-background-color, 15%);
+  background-color: mix(@contrast, @syntax-background-color, 20%);
 }


### PR DESCRIPTION
@harai Hello :)

I adjusted the default styling a bit, and couldn't find any declaration of the `@syntax-indent-guide-color` variable, so I removed it's use. Furthermore I move the indent lines one column to the right, but added some buffer - half an editor character.

Take it as a suggestion, if you don't like the changes, it's fine :+1: 

PS: I'm pretty new to atom packages (or node, for that matter), so I hope I didn't oversee a declaration of the `@syntax-indent-guide-color` variable.
