### PR TITLE
Update on font style changes

### DIFF
--- a/lib/indent-guide-improved.coffee
+++ b/lib/indent-guide-improved.coffee
@@ -58,9 +58,18 @@ module.exports =
       up = () ->
         updateGuide(editor, editorElement)
 
+      delayedUpdate = ->
+        setTimeout(up, 0)
+
       update = _.throttle(up , 30)
 
       subscriptions = new CompositeDisposable
+      subscriptions.add atom.workspace.onDidStopChangingActivePaneItem((item) ->
+        delayedUpdate() if item == editor
+      )
+      subscriptions.add atom.config.onDidChange('editor.fontSize', delayedUpdate)
+      subscriptions.add atom.config.onDidChange('editor.fontFamily', delayedUpdate)
+      subscriptions.add atom.config.onDidChange('editor.lineHeight', delayedUpdate)
       subscriptions.add editor.onDidChangeCursorPosition(update)
       subscriptions.add editorElement.onDidChangeScrollTop(update)
       subscriptions.add editorElement.onDidChangeScrollLeft(update)
@@ -75,6 +84,7 @@ module.exports =
       editorElement = atom.views.getView(editor)
       return unless editorElement?
       handleEvents(editor, editorElement)
+      updateGuide(editor, editorElement)
 
   deactivate: () ->
     @currentSubscriptions.forEach (s) ->


### PR DESCRIPTION
Fixes #21 

Only visible TextEditors get refreshed when you change the settings so this updates on active item change to catch up inactive tabs, and regardless, the change event fires before the presenter updates, so setTimeout 0 is used to push the update to the end of the call stack.