### PR TITLE
Explicitly check whether the useShadowDOM preference is false

### DIFF
--- a/lib/indent-guide-improved.coffee
+++ b/lib/indent-guide-improved.coffee
@@ -11,7 +11,7 @@ module.exports =
     # The original indent guides interfere with this package.
     atom.config.set('editor.showIndentGuide', false)
 
-    unless atom.config.get('editor.useShadowDOM')
+    if atom.config.get('editor.useShadowDOM') is false
       msg = 'To use indent-guide-improved package, please check "Use Shadow DOM" in Settings.'
       atom.notifications.addError(msg, {dismissable: true})
       return


### PR DESCRIPTION
The useShadowDOM preference was removed from Atom in [this commit](https://github.com/atom/atom/commit/738a2b90dc8e267d5d286ea490efd40c46a5f7eb). The removal causes this package to show the Shadow DOM error dialog every time the application is launched, even though the Shadow DOM is now always enabled.

This pull request changes the "unless" to explicitly check whether the useShadowDOM preference is false, maintaining compatibility with older versions of Atom while accepting newer versions that are lacking the preference.