### PR TITLE
Move all updates into a rAF callback.

### DIFF
--- a/lib/indent-guide-improved.coffee
+++ b/lib/indent-guide-improved.coffee
@@ -51,9 +51,7 @@ module.exports =
         updateGuide(editor, editorElement)
 
       delayedUpdate = ->
-        setTimeout(up, 0)
-
-      update = _.throttle(up , 30)
+        requestAnimationFrame(up)
 
       subscriptions = new CompositeDisposable
       subscriptions.add atom.workspace.onDidStopChangingActivePaneItem((item) ->
@@ -62,10 +60,10 @@ module.exports =
       subscriptions.add atom.config.onDidChange('editor.fontSize', delayedUpdate)
       subscriptions.add atom.config.onDidChange('editor.fontFamily', delayedUpdate)
       subscriptions.add atom.config.onDidChange('editor.lineHeight', delayedUpdate)
-      subscriptions.add editor.onDidChangeCursorPosition(update)
-      subscriptions.add editorElement.onDidChangeScrollTop(update)
-      subscriptions.add editorElement.onDidChangeScrollLeft(update)
-      subscriptions.add editor.onDidStopChanging(update)
+      subscriptions.add editor.onDidChangeCursorPosition(delayedUpdate)
+      subscriptions.add editorElement.onDidChangeScrollTop(delayedUpdate)
+      subscriptions.add editorElement.onDidChangeScrollLeft(delayedUpdate)
+      subscriptions.add editor.onDidStopChanging(delayedUpdate)
       subscriptions.add editor.onDidDestroy =>
         @currentSubscriptions.splice(@currentSubscriptions.indexOf(subscriptions), 1)
         subscriptions.dispose()

--- a/lib/indent-guide-improved.coffee
+++ b/lib/indent-guide-improved.coffee
@@ -1,5 +1,4 @@
 {CompositeDisposable, Point} = require 'atom'
-_ = require 'lodash'
 
 {createElementsForGuides, styleGuide} = require './indent-guide-improved-element'
 {getGuides} = require './guides.coffee'

--- a/lib/indent-guide-improved.coffee
+++ b/lib/indent-guide-improved.coffee
@@ -6,6 +6,7 @@
 module.exports =
   activate: (state) ->
     @currentSubscriptions = []
+    @busy = false
 
     # The original indent guides interfere with this package.
     atom.config.set('editor.showIndentGuide', false)
@@ -46,11 +47,14 @@ module.exports =
 
 
     handleEvents = (editor, editorElement) =>
-      up = () ->
+      up = () =>
         updateGuide(editor, editorElement)
+        @busy = false
 
-      delayedUpdate = ->
-        requestAnimationFrame(up)
+      delayedUpdate = =>
+        unless @busy
+          @busy = true
+          requestAnimationFrame(up)
 
       subscriptions = new CompositeDisposable
       subscriptions.add atom.workspace.onDidStopChangingActivePaneItem((item) ->

--- a/package.json
+++ b/package.json
@@ -14,7 +14,5 @@
     "ruler",
     "ui"
   ],
-  "dependencies": {
-    "lodash": "^3.9.3"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
Hey there! I'm a big fan of this package's look, but always found its performance a little disappointing. After poking around in the code for a solution, I went for the lowest-hanging fruit in this PR: in lieu of throttling updates against a static timeout, this passes them through `requestAnimationFrame` and lets Chromium figure out when it can afford them.

It's not perfect---the guides still visibly stutter a bit as they receive their updates---but it at least stops blocking the main thread, bringing scroll performance nearly (_nearly_) back to native quality. I definitely hope to keep fiddling when I have the time, but this felt like an easy win.

###### Before—`_.throttle`
![before](https://cloud.githubusercontent.com/assets/2207980/25206012/8ed89508-2533-11e7-82b0-9f0aac901093.gif)

###### After—`requestAnimationFrame`
![after](https://cloud.githubusercontent.com/assets/2207980/25206024/9d3ec5b8-2533-11e7-916b-6b408b5794ff.gif)

Thanks for all your hard work here! Hope this little contribution helps.