### PR TITLE
Fix for 'TypeError: Invalid Point: (NaN, 0)' error in latest version of atom

### DIFF
--- a/lib/indent-guide-improved.coffee
+++ b/lib/indent-guide-improved.coffee
@@ -13,7 +13,7 @@ module.exports =
     
     createPoint = (x, y) ->
     	x = if isNaN(x) then 0 else x
-    	x = if isNaN(y) then 0 else y
+    	y = if isNaN(y) then 0 else y
     	new Point(x, y)
 
     updateGuide = (editor, editorElement) ->

--- a/lib/indent-guide-improved.coffee
+++ b/lib/indent-guide-improved.coffee
@@ -10,13 +10,18 @@ module.exports =
 
     # The original indent guides interfere with this package.
     atom.config.set('editor.showIndentGuide', false)
+    
+    createPoint = (x, y) ->
+    	x = if isNaN(x) then 0 else x
+    	x = if isNaN(y) then 0 else y
+    	new Point(x, y)
 
     updateGuide = (editor, editorElement) ->
       visibleScreenRange = editorElement.getVisibleRowRange()
       return unless visibleScreenRange? and editorElement.component?
-      basePixelPos = editorElement.pixelPositionForScreenPosition(new Point(visibleScreenRange[0], 0)).top
+      basePixelPos = editorElement.pixelPositionForScreenPosition(createPoint(visibleScreenRange[0], 0)).top
       visibleRange = visibleScreenRange.map (row) ->
-        editor.bufferPositionForScreenPosition(new Point(row, 0)).row
+        editor.bufferPositionForScreenPosition(createPoint(row, 0)).row
       getIndent = (row) ->
         if editor.lineTextForBufferRow(row).match(/^\s*$/)
           null
@@ -34,7 +39,7 @@ module.exports =
       createElementsForGuides(editorElement, guides.map (g) ->
         (el) -> styleGuide(
           el,
-          g.point.translate(new Point(visibleRange[0], 0)),
+          g.point.translate(createPoint(visibleRange[0], 0)),
           g.length,
           g.stack,
           g.active,


### PR DESCRIPTION
Fixes the following error:

TypeError: Invalid Point: (NaN, 0)
    at Function.module.exports.Point.assertValid (/Applications/Atom.app/Contents/Resources/app/node_modules/text-buffer/lib/point.js:63:21)
    at DisplayLayer.translateScreenPosition (/Applications/Atom.app/Contents/Resources/app/node_modules/text-buffer/lib/display-layer.js:333:17)
    at DisplayLayer.clipScreenPosition (/Applications/Atom.app/Contents/Resources/app/node_modules/text-buffer/lib/display-layer.js:391:18)
    at TextEditor.module.exports.TextEditor.clipScreenPosition (/Applications/Atom.app/Contents/Resources/app/src/text-editor.js:1790:38)
    at HTMLElement.pixelPositionForScreenPosition (/Applications/Atom.app/Contents/Resources/app/src/text-editor-element.js:242:38)
    at updateGuide (/Users/denis/.atom/packages/indent-guide-improved/lib/indent-guide-improved.coffee:17:36)
    at /Users/denis/.atom/packages/indent-guide-improved/lib/indent-guide-improved.coffee:79:7
    at Workspace.observeTextEditors (/Applications/Atom.app/Contents/Resources/app/src/workspace.js:703:15)
    at Object.activate (/Users/denis/.atom/packages/indent-guide-improved/lib/indent-guide-improved.coffee:74:20)
    at Package.module.exports.Package.activateNow (/Applications/Atom.app/Contents/Resources/app/src/package.js:253:25)
    at /Applications/Atom.app/Contents/Resources/app/src/package.js:225:38
    at Package.module.exports.Package.measure (/Applications/Atom.app/Contents/Resources/app/src/package.js:99:21)
    at /Applications/Atom.app/Contents/Resources/app/src/package.js:218:32
    at Package.module.exports.Package.activate (/Applications/Atom.app/Contents/Resources/app/src/package.js:215:40)
    at PackageManager.module.exports.PackageManager.activatePackage (/Applications/Atom.app/Contents/Resources/app/src/package-manager.js:645:40)
    at /Applications/Atom.app/Contents/Resources/app/src/package-manager.js:626:35
    at Config.module.exports.Config.transactAsync (/Applications/Atom.app/Contents/Resources/app/src/config.js:346:24)
    at PackageManager.module.exports.PackageManager.activatePackages (/Applications/Atom.app/Contents/Resources/app/src/package-manager.js:621:25)
    at PackageManager.module.exports.PackageManager.activate (/Applications/Atom.app/Contents/Resources/app/src/package-manager.js:603:52)
    at /Applications/Atom.app/Contents/Resources/app/src/atom-environment.js:842:34